### PR TITLE
Fixed project setup for Eclilpse

### DIFF
--- a/astrid/.classpath
+++ b/astrid/.classpath
@@ -15,7 +15,10 @@
 	<classpathentry exported="true" kind="lib" path="libs/locale_platform.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/todoroo-g.jar"/>
 	<classpathentry kind="lib" path="libs/framework.jar"/>
-	<classpathentry kind="src" path="astridApi_src"/>
+	<classpathentry combineaccessrules="false" exported="true" kind="src" path="/astridApi"/>
+	<classpathentry combineaccessrules="false" exported="true" kind="src" path="/GDCatalog"/>
+	<classpathentry combineaccessrules="false" exported="true" kind="src" path="/GreenDroid"/>
 	<classpathentry kind="src" path="GreenDroid_src"/>
+	<classpathentry kind="src" path="astridApi_src"/>
 	<classpathentry kind="output" path="ecbuild"/>
 </classpath>

--- a/astrid/.project
+++ b/astrid/.project
@@ -47,10 +47,5 @@
 			<type>2</type>
 			<locationURI>_android_astridApi_98e6a2cf/src</locationURI>
 		</link>
-		<link>
-			<name>astridApi_src</name>
-			<type>2</type>
-			<locationURI>_android_astridApi_98e6a2cf/src</locationURI>
-		</link>
 	</linkedResources>
 </projectDescription>

--- a/astrid/astrid.launch
+++ b/astrid/astrid.launch
@@ -7,6 +7,7 @@
 <stringAttribute key="ch.zork.quicklaunch.mode" value="run"/>
 <intAttribute key="com.android.ide.eclipse.adt.action" value="0"/>
 <stringAttribute key="com.android.ide.eclipse.adt.activity" value="com.todoroo.astrid.gtasks.GtasksPreferences"/>
+<stringAttribute key="com.android.ide.eclipse.adt.avd" value="galaxy_tab"/>
 <stringAttribute key="com.android.ide.eclipse.adt.commandline" value="-scale 0.7"/>
 <intAttribute key="com.android.ide.eclipse.adt.delay" value="0"/>
 <booleanAttribute key="com.android.ide.eclipse.adt.nobootanim" value="true"/>

--- a/greendroid/GDCatalog/.classpath
+++ b/greendroid/GDCatalog/.classpath
@@ -3,6 +3,7 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="gen"/>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/GreenDroid"/>
 	<classpathentry kind="src" path="GreenDroid_src"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/tests/.classpath
+++ b/tests/.classpath
@@ -4,5 +4,6 @@
 	<classpathentry kind="src" path="gen"/>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/astrid"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/astridApi"/>
 	<classpathentry kind="output" path="ecbuild"/>
 </classpath>


### PR DESCRIPTION
Hi,

this is me, Arne.

I fixed project setup for compiling and running bleeding-edge Astrid in Eclipse with this patch.
I added library projects in the respective build paths (due to classes from astridApi and greendroid not found during compilation) and added export-entries for astridApi, GDcatalog and GreenDroid to astrid-project (due to NoClassDefFoundError during Astrid-startup).

Some of these changes might be unnecessary, but I dont know exactly which, as Eclipse behaves jerky sometimes. I think these changes dont hurt, either.

Please pull those changes in (if you approve), so that I can merge them into my normal repo.

Regards,

Arne
