### PR TITLE
Update to import uniqueness

### DIFF
--- a/astrid/plugin-src/com/todoroo/astrid/backup/TasksXmlImporter.java
+++ b/astrid/plugin-src/com/todoroo/astrid/backup/TasksXmlImporter.java
@@ -225,9 +225,12 @@ public class TasksXmlImporter {
 
             String title = xpp.getAttributeValue(null, Task.TITLE.name);
             String created = xpp.getAttributeValue(null, Task.CREATION_DATE.name);
+            String dueDate = xpp.getAttributeValue(null, Task.DUE_DATE.name);
+            String completionDate = xpp.getAttributeValue(null, Task.COMPLETION_DATE.name);
 
             // if we don't have task name or creation date, skip
-            if (created == null || title == null) {
+            if (created == null || title == null || dueDate == null
+                    || completionDate == null) {
                 skipCount++;
                 return;
             }
@@ -235,7 +238,9 @@ public class TasksXmlImporter {
             // if the task's name and creation date match an existing task, skip
             TodorooCursor<Task> cursor = taskService.query(Query.select(Task.ID).
                     where(Criterion.and(Task.TITLE.eq(title),
-                            Task.CREATION_DATE.eq(created))));
+                            Task.CREATION_DATE.eq(created),
+                            Task.DUE_DATE.eq(dueDate),
+                            Task.COMPLETION_DATE.eq(completionDate))));
             try {
                 if(cursor.getCount() > 0) {
                     skipCount++;

--- a/astrid/res/values/strings-core.xml
+++ b/astrid/res/values/strings-core.xml
@@ -110,6 +110,9 @@
   <!-- Context Item: edit task -->
   <string name="TAd_contextEditTask">Edit Task</string>
 
+  <!-- Context Item: copy task -->
+  <string name="TAd_contextCopyTask">Copy Task</string>
+
   <!-- Context Item: delete task -->
   <string name="TAd_contextDeleteTask">Delete Task</string>
 

--- a/astrid/src/com/todoroo/astrid/activity/TaskListActivity.java
+++ b/astrid/src/com/todoroo/astrid/activity/TaskListActivity.java
@@ -64,6 +64,7 @@ import com.todoroo.andlib.service.ContextManager;
 import com.todoroo.andlib.service.DependencyInjectionService;
 import com.todoroo.andlib.service.ExceptionService;
 import com.todoroo.andlib.utility.AndroidUtilities;
+import com.todoroo.andlib.utility.DateUtilities;
 import com.todoroo.andlib.utility.Preferences;
 import com.todoroo.andlib.widget.GestureService;
 import com.todoroo.andlib.widget.GestureService.GestureInterface;
@@ -77,6 +78,7 @@ import com.todoroo.astrid.api.SyncAction;
 import com.todoroo.astrid.api.TaskAction;
 import com.todoroo.astrid.api.TaskDecoration;
 import com.todoroo.astrid.core.CoreFilterExposer;
+import com.todoroo.astrid.core.PluginServices;
 import com.todoroo.astrid.core.SortHelper;
 import com.todoroo.astrid.dao.Database;
 import com.todoroo.astrid.dao.TaskDao.TaskCriteria;
@@ -129,10 +131,11 @@ public class TaskListActivity extends ListActivity implements OnScrollListener,
     private static final int MENU_ADDON_INTENT_ID = Menu.FIRST + 6;
 
     private static final int CONTEXT_MENU_EDIT_TASK_ID = Menu.FIRST + 20;
-    private static final int CONTEXT_MENU_DELETE_TASK_ID = Menu.FIRST + 21;
-    private static final int CONTEXT_MENU_UNDELETE_TASK_ID = Menu.FIRST + 22;
-    private static final int CONTEXT_MENU_PURGE_TASK_ID = Menu.FIRST + 23;
-    private static final int CONTEXT_MENU_ADDON_INTENT_ID = Menu.FIRST + 24;
+    private static final int CONTEXT_MENU_COPY_TASK_ID = Menu.FIRST + 21;
+    private static final int CONTEXT_MENU_DELETE_TASK_ID = Menu.FIRST + 22;
+    private static final int CONTEXT_MENU_UNDELETE_TASK_ID = Menu.FIRST + 23;
+    private static final int CONTEXT_MENU_PURGE_TASK_ID = Menu.FIRST + 24;
+    private static final int CONTEXT_MENU_ADDON_INTENT_ID = Menu.FIRST + 25;
 
     private static final int CONTEXT_MENU_DEBUG = Menu.FIRST + 30;
 
@@ -806,6 +809,8 @@ public class TaskListActivity extends ListActivity implements OnScrollListener,
         } else {
             menu.add(id, CONTEXT_MENU_EDIT_TASK_ID, Menu.NONE,
                         R.string.TAd_contextEditTask);
+            menu.add(id, CONTEXT_MENU_COPY_TASK_ID, Menu.NONE,
+                    R.string.TAd_contextCopyTask);
             menu.add(id, CONTEXT_MENU_DELETE_TASK_ID, Menu.NONE,
                     R.string.TAd_contextDeleteTask);
 
@@ -995,6 +1000,23 @@ public class TaskListActivity extends ListActivity implements OnScrollListener,
             intent = new Intent(TaskListActivity.this, TaskEditActivity.class);
             intent.putExtra(TaskEditActivity.TOKEN_ID, itemId);
             startActivityForResult(intent, ACTIVITY_EDIT_TASK);
+            return true;
+        }
+
+        case CONTEXT_MENU_COPY_TASK_ID: {
+            itemId = item.getGroupId();
+            Task original = new Task();
+            original.setId(itemId);
+
+            Task clone = PluginServices.getTaskService().clone(original);
+            clone.setValue(Task.CREATION_DATE, DateUtilities.now());
+            clone.setValue(Task.MODIFICATION_DATE, DateUtilities.now());
+            PluginServices.getTaskService().save(clone);
+
+            intent = new Intent(TaskListActivity.this, TaskEditActivity.class);
+            intent.putExtra(TaskEditActivity.TOKEN_ID, clone.getId());
+            startActivityForResult(intent, ACTIVITY_EDIT_TASK);
+
             return true;
         }
 


### PR DESCRIPTION
In reference to:
http://getsatisfaction.com/todoroo/topics/importing_duplicates_missing_tasks

I don't particularly like this approach to uniqueness but at least this changeset covers the basic case created by Astrid's built-in recurring tasks feature.  Without it the import procedure simply keeps the first instance of a recurring task (likely the oldest?) and throws away all others (usually including the one that hasn't been completed yet).
