### PR TITLE
duplicate-fix for locally renaming tasks in Astrid, also fix for deleting workspaces remotely

### DIFF
--- a/api/src/com/todoroo/astrid/sync/SyncProvider.java
+++ b/api/src/com/todoroo/astrid/sync/SyncProvider.java
@@ -276,8 +276,8 @@ public abstract class SyncProvider<TYPE extends SyncContainer> {
                     TYPE remote = data.remoteUpdated.get(remoteIndex);
                     push(local, remote);
 
-                    // re-read remote task after merge
-                    remote = pull(remote);
+                    // re-read remote task after merge (with local's title)
+                    remote = pull(local);
                     remote.task.setId(local.task.getId());
                     data.remoteUpdated.set(remoteIndex, remote);
                 } else {

--- a/astrid/plugin-src/com/todoroo/astrid/producteev/sync/ProducteevSyncProvider.java
+++ b/astrid/plugin-src/com/todoroo/astrid/producteev/sync/ProducteevSyncProvider.java
@@ -220,7 +220,7 @@ public class ProducteevSyncProvider extends SyncProvider<ProducteevTaskContainer
             String lastActivityId = Preferences.getStringValue(ProducteevUtilities.PREF_SERVER_LAST_ACTIVITY);
 
             // read dashboards
-            JSONArray dashboards = invoker.dashboardsShowList(null);
+            JSONArray dashboards = invoker.dashboardsShowList(lastServerSync);
             dataService.updateDashboards(dashboards);
 
             // read labels and tasks for each dashboard


### PR DESCRIPTION
Hi,

Should result in fewer duplicates if you rename tasks either in Astrid or on serverside.
I also fixed syncing deleted workspaces from the website. Now they get deleted in Astrid too during next sync.

You may want to check those two out.

Arne
