### PR TITLE
Make Google Tasks lists respect the "Display Completed" preference flag.

### DIFF
--- a/astrid/plugin-src/com/todoroo/astrid/gtasks/GtasksFilterExposer.java
+++ b/astrid/plugin-src/com/todoroo/astrid/gtasks/GtasksFilterExposer.java
@@ -61,6 +61,7 @@ public class GtasksFilterExposer extends BroadcastReceiver {
                 Join.left(Metadata.TABLE, Task.ID.eq(Metadata.TASK))).where(Criterion.and(
                         MetadataCriteria.withKey(GtasksMetadata.METADATA_KEY),
                         TaskCriteria.notDeleted(),
+                        TaskCriteria.isActive(),
                         GtasksMetadata.LIST_ID.eq(list.getValue(GtasksList.REMOTE_ID)))).orderBy(
                                 Order.asc(Functions.cast(GtasksMetadata.ORDER, "INTEGER"))), //$NON-NLS-1$
                 values);


### PR DESCRIPTION
Signed-off-by: Ian Fraser ian@.bigwave.org.uk
