### PR TITLE
Added 'In two weeks' and 'next month' options to the deadline picker

### DIFF
--- a/api/src/com/todoroo/astrid/data/Task.java
+++ b/api/src/com/todoroo/astrid/data/Task.java
@@ -326,6 +326,7 @@ public final class Task extends RemoteModel {
     public static final int URGENCY_NEXT_MONTH = 5;
     public static final int URGENCY_SPECIFIC_DAY = 6;
     public static final int URGENCY_SPECIFIC_DAY_TIME = 7;
+    public static final int URGENCY_IN_TWO_WEEKS = 8;
 
     /** hide until array index -> significance */
     public static final int HIDE_UNTIL_NONE = 0;
@@ -362,6 +363,9 @@ public final class Task extends RemoteModel {
             break;
         case URGENCY_NEXT_WEEK:
             date = DateUtilities.now() + DateUtilities.ONE_WEEK;
+            break;
+        case URGENCY_IN_TWO_WEEKS:
+            date = DateUtilities.now() + DateUtilities.ONE_WEEK + DateUtilities.ONE_WEEK;
             break;
         case URGENCY_NEXT_MONTH:
             date = DateUtilities.oneMonthFromNow();

--- a/astrid/res/values/strings-core.xml
+++ b/astrid/res/values/strings-core.xml
@@ -299,6 +299,8 @@
       <item>Tomorrow</item>
       <item>(day after)</item>
       <item>Next Week</item>
+      <item>In Two Weeks</item>
+      <item>Next Month</item>
       <item>No Deadline</item>
   </string-array>
   

--- a/astrid/src/com/todoroo/astrid/activity/TaskEditActivity.java
+++ b/astrid/src/com/todoroo/astrid/activity/TaskEditActivity.java
@@ -888,6 +888,10 @@ public final class TaskEditActivity extends TabActivity {
             urgencyValues[4] = new UrgencyValue(labels[4],
                     Task.URGENCY_NEXT_WEEK);
             urgencyValues[5] = new UrgencyValue(labels[5],
+                    Task.URGENCY_IN_TWO_WEEKS);
+            urgencyValues[6] = new UrgencyValue(labels[6],
+                    Task.URGENCY_NEXT_MONTH);
+            urgencyValues[7] = new UrgencyValue(labels[7],
                     Task.URGENCY_NONE);
 
             // search for setting


### PR DESCRIPTION
This is going to require localization to work properly. In the "createUrgencyList" method of TaskEditActivity.UrgencyControlSet, there is a hardcoded mapping between indices and UrgencyValues, which means that the string array R.array.TEA_urgency must be the same length in all languages for the code to work. With the edits in this commit, it works in English but causes an array-out-of-bounds error in other languages that crashes the app--so don't merge it into master until that's fixed!
