### PR TITLE
Fix for 13186807 (Create option to override ringer volume)

### DIFF
--- a/astrid/plugin-src/com/todoroo/astrid/reminders/ReminderPreferences.java
+++ b/astrid/plugin-src/com/todoroo/astrid/reminders/ReminderPreferences.java
@@ -68,6 +68,11 @@ public class ReminderPreferences extends TodorooPreferenceActivity {
                 preference.setSummary(r.getString(R.string.rmd_EPr_persistent_desc_true));
             else
                 preference.setSummary(r.getString(R.string.rmd_EPr_persistent_desc_false));
+        } else if(r.getString(R.string.p_rmd_maxvolume).equals(preference.getKey())) {
+            if((Boolean)value)
+                preference.setSummary(r.getString(R.string.rmd_EPr_multiple_maxvolume_desc_true));
+            else
+                preference.setSummary(r.getString(R.string.rmd_EPr_multiple_maxvolume_desc_false));
         } else if(r.getString(R.string.p_rmd_vibrate).equals(preference.getKey())) {
             if((Boolean)value)
                 preference.setSummary(r.getString(R.string.rmd_EPr_vibrate_desc_true));

--- a/astrid/res/values-de/strings.xml
+++ b/astrid/res/values-de/strings.xml
@@ -1472,12 +1472,19 @@ Achtung: diese Aufgaben sind unwiederbringlich verloren, wenn Sie kein Backup ge
   <!-- Reminder Preference: Notification Icon Description -->
   <string name="rmd_Epr_notificon_desc">Astrid\'s Notification Bar Icon auswählen</string>
 
+  <!-- Reminder Preference: Max Volume for Multiple-Ring reminders Title -->
+  <string name="rmd_EPr_multiple_maxvolume_title">Lautstärke hoch bei wdh. Alarm</string>
+  <!-- Reminder Preference: Max Volume for Multiple-Ring reminders Description (true) -->
+  <string name="rmd_EPr_multiple_maxvolume_desc_true">Astrid wird bei mehrfach alarmierenden Aufgaben laut sein</string>
+  <!-- Reminder Preference: Max Volume for Multiple-Ring reminders Description (false) -->
+  <string name="rmd_EPr_multiple_maxvolume_desc_false">Astrid verwendet die Lautstärke der Systemeinstellung</string>
+
   <!-- Reminder Preference: Vibrate Title -->
   <string name="rmd_EPr_vibrate_title">Vibrieren beim Alarm</string>
   <!-- Reminder Preference: Vibrate Description (true) -->
   <string name="rmd_EPr_vibrate_desc_true">Astrid wird bei Benachrichtigungen vibrieren</string>
   <!-- Reminder Preference: Vibrate Description (false) -->
-  <string name="rmd_EPr_vibrate_desc_false">Astrid wird bei Erinnerungen nicht vibrieren</string>
+  <string name="rmd_EPr_vibrate_desc_false">Astrid wird bei Benachrichtigungen nicht vibrieren</string>
 
   <!-- Reminder Preference: Nagging Title -->  
   <string name="rmd_EPr_nagging_title">Astrid Ermutigungen</string>

--- a/astrid/res/values/keys.xml
+++ b/astrid/res/values/keys.xml
@@ -19,6 +19,9 @@
   <!-- whether "clear all notifications" clears astrid notifications -->
   <string name="p_rmd_persistent">notif_annoy</string>
   
+  <!-- whether to max out the notification reminder volume if reminder has setting "ring multiple" or "ring continuous" -->
+  <string name="p_rmd_maxvolume">notif_maxvol</string>
+  
   <!-- whether to vibrate phone when reminder fires -->
   <string name="p_rmd_vibrate">notif_vibrate</string>
   

--- a/astrid/res/values/strings-reminders.xml
+++ b/astrid/res/values/strings-reminders.xml
@@ -97,6 +97,13 @@
   <!-- Reminder Preference: Notification Icon Description -->
   <string name="rmd_Epr_notificon_desc">Choose Astrid\'s notification bar icon</string>
 
+  <!-- Reminder Preference: Max Volume for Multiple-Ring reminders Title -->
+  <string name="rmd_EPr_multiple_maxvolume_title">Max volume for multiple-ring reminders</string>
+  <!-- Reminder Preference: Max Volume for Multiple-Ring reminders Description (true) -->
+  <string name="rmd_EPr_multiple_maxvolume_desc_true">Astrid will max out the volume for multiple-ring reminders</string>
+  <!-- Reminder Preference: Max Volume for Multiple-Ring reminders Description (false) -->
+  <string name="rmd_EPr_multiple_maxvolume_desc_false">Astrid will use the system-setting for the volume</string>
+
   <!-- Reminder Preference: Vibrate Title -->
   <string name="rmd_EPr_vibrate_title">Vibrate on Alert</string>
   <!-- Reminder Preference: Vibrate Description (true) -->

--- a/astrid/res/xml/preferences_reminders.xml
+++ b/astrid/res/xml/preferences_reminders.xml
@@ -22,6 +22,10 @@
         android:key="@string/p_rmd_persistent"
         android:title="@string/rmd_EPr_persistent_title"/>
     <CheckBoxPreference
+        android:key="@string/p_rmd_maxvolume"
+        android:title="@string/rmd_EPr_multiple_maxvolume_title"
+        android:defaultValue="false"  />
+    <CheckBoxPreference
         android:key="@string/p_rmd_vibrate"
         android:title="@string/rmd_EPr_vibrate_title"
         android:defaultValue="true"  />


### PR DESCRIPTION
Fix for 13186807. New setting default is to behave as before, max-out the volume for multiple rings. Discussion about behaviour of new setting during silent-mode is still open (see flowdock-history for this from 7/11/2011)
