### PR TITLE
Fix for Snooze for x hours / isn't label but not default functionality

### DIFF
--- a/astrid/plugin-src/com/todoroo/astrid/reminders/NotificationActivity.java
+++ b/astrid/plugin-src/com/todoroo/astrid/reminders/NotificationActivity.java
@@ -199,7 +199,7 @@ public class NotificationActivity extends TaskListActivity implements OnTimeSetL
      * Snooze and re-trigger this alarm
      */
     private void snooze() {
-        if(Preferences.getBoolean(R.string.p_rmd_snooze_dialog, true)) {
+        if(Preferences.getBoolean(R.string.p_rmd_snooze_dialog, false)) {
             Date now = new Date();
             now.setHours(now.getHours() + 1);
             int hour = now.getHours();


### PR DESCRIPTION
Fix for -Snooze for x hours / isn't label but not default functionality for snooze options.- 15344073. It was only faulty directly after install as the setting-value wasnt written yet and the NotificationActivity assumed the wrong default-value.
