### PR TITLE
Potential fix for User cannot start Astrid due to force close

### DIFF
--- a/astrid/common-src/com/localytics/android/UploaderThread.java
+++ b/astrid/common-src/com/localytics/android/UploaderThread.java
@@ -298,6 +298,11 @@ public class UploaderThread extends Thread
 			{
 				Log.v(LOG_TAG, "IOException: " + e.getMessage());
 			}
+            catch (OutOfMemoryError e)
+            {
+                e.printStackTrace();
+                Log.v(LOG_TAG, "OutOfMemoryError: " + e.getMessage());
+            }
 		}
 
 		return postBody.toString();


### PR DESCRIPTION
Potential fix for User cannot start Astrid due to force close (Localytics OutOfMemoryError)
