### PR TITLE
Implemented gcal-default-setting and fixed some bugs with gcal-integratio

### DIFF
--- a/astrid/plugin-src/com/todoroo/astrid/core/DefaultsPreferences.java
+++ b/astrid/plugin-src/com/todoroo/astrid/core/DefaultsPreferences.java
@@ -5,12 +5,15 @@ package com.todoroo.astrid.core;
 
 import android.content.SharedPreferences.Editor;
 import android.content.res.Resources;
+import android.os.Bundle;
+import android.preference.ListPreference;
 import android.preference.Preference;
 
 import com.timsu.astrid.R;
 import com.todoroo.andlib.utility.AndroidUtilities;
 import com.todoroo.andlib.utility.Preferences;
 import com.todoroo.andlib.utility.TodorooPreferenceActivity;
+import com.todoroo.astrid.gcal.Calendars;
 
 /**
  * Displays the preference screen for users to edit their preferences
@@ -23,6 +26,14 @@ public class DefaultsPreferences extends TodorooPreferenceActivity {
     @Override
     public int getPreferenceResource() {
         return R.xml.preferences_defaults;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        ListPreference defaultCalendarPreference = (ListPreference) findPreference(getString(R.string.gcal_p_default));
+        Calendars.initCalendarsPreference(this, defaultCalendarPreference);
     }
 
     /**
@@ -53,6 +64,15 @@ public class DefaultsPreferences extends TodorooPreferenceActivity {
             else {
                 String setting = r.getStringArray(R.array.EPr_reminder_random)[index];
                 preference.setSummary(r.getString(R.string.rmd_EPr_defaultRemind_desc, setting));
+            }
+        } else if(r.getString(R.string.gcal_p_default).equals(preference.getKey())) {
+            ListPreference listPreference = (ListPreference) preference;
+            int index = AndroidUtilities.indexOf(listPreference.getEntryValues(), (String)value);
+            if(index <= 0)
+                preference.setSummary(r.getString(R.string.EPr_default_addtocalendar_desc_disabled));
+            else {
+                String setting = listPreference.getEntries()[index].toString();
+                preference.setSummary(r.getString(R.string.EPr_default_addtocalendar_desc, setting));
             }
         }
     }

--- a/astrid/plugin-src/com/todoroo/astrid/gcal/GCalHelper.java
+++ b/astrid/plugin-src/com/todoroo/astrid/gcal/GCalHelper.java
@@ -1,16 +1,75 @@
 package com.todoroo.astrid.gcal;
 
+import java.util.TimeZone;
+
 import android.content.ContentResolver;
+import android.content.ContentValues;
 import android.database.Cursor;
 import android.net.Uri;
 import android.text.TextUtils;
 import android.util.Log;
 
 import com.todoroo.andlib.service.ContextManager;
+import com.todoroo.andlib.utility.DateUtilities;
 import com.todoroo.astrid.core.PluginServices;
 import com.todoroo.astrid.data.Task;
 
 public class GCalHelper {
+    /** If task has no estimated time, how early to set a task in calendar (seconds)*/
+    private static final long DEFAULT_CAL_TIME = DateUtilities.ONE_HOUR;
+
+    public static String getTaskEventUri(Task task) {
+        String uri;
+        if (!TextUtils.isEmpty(task.getValue(Task.CALENDAR_URI)))
+            uri = task.getValue(Task.CALENDAR_URI);
+        else {
+            task = PluginServices.getTaskService().fetchById(task.getId(), Task.CALENDAR_URI);
+            if(task == null)
+                return null;
+            uri = task.getValue(Task.CALENDAR_URI);
+        }
+
+        return uri;
+    }
+
+    public static Uri createTaskEvent(Task task, ContentResolver cr, ContentValues values) {
+        String eventuri = getTaskEventUri(task);
+
+        if(!TextUtils.isEmpty(eventuri)) {
+            deleteTaskEvent(task);
+        }
+
+        try{
+            // FIXME test this with empty quickadd and full quickadd and taskedit-page
+            Uri uri = Calendars.getCalendarContentUri(Calendars.CALENDAR_CONTENT_EVENTS);
+            values.put("title", task.getValue(Task.TITLE));
+            values.put("description", task.getValue(Task.NOTES));
+            values.put("hasAlarm", 0);
+            values.put("transparency", 0);
+            values.put("visibility", 0);
+            boolean valuesContainCalendarId = (values.containsKey("calendar_id") &&
+                    !TextUtils.isEmpty(values.getAsString("calendar_id")));
+            if (!valuesContainCalendarId) {
+                String calendarId = Calendars.getDefaultCalendar();
+                if (!TextUtils.isEmpty(calendarId)) {
+                    values.put("calendar_id", calendarId);
+                }
+            }
+
+            createStartAndEndDate(task, values);
+
+            Uri eventUri = cr.insert(uri, values);
+            cr.notifyChange(eventUri, null);
+
+            return eventUri;
+
+        } catch (Exception e) {
+            Log.e("astrid-gcal", "error-creating-calendar-event", e); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+
+        return null;
+    }
+
     public static void deleteTaskEvent(Task task) {
         String uri;
         if(task.containsNonNullValue(Task.CALENDAR_URI))
@@ -35,9 +94,38 @@ public class GCalHelper {
                 if (!deleted) {
                     cr.delete(calendarUri, null, null);
                 }
+
+                task.setValue(Task.CALENDAR_URI,"");
             } catch (Exception e) {
                 Log.e("astrid-gcal", "error-deleting-calendar-event", e); //$NON-NLS-1$ //$NON-NLS-2$
             }
+        }
+    }
+
+    @SuppressWarnings("nls")
+    static void createStartAndEndDate(Task task, ContentValues values) {
+        long dueDate = task.getValue(Task.DUE_DATE);
+        long tzCorrectedDueDate = dueDate + TimeZone.getDefault().getOffset(dueDate);
+        long tzCorrectedDueDateNow = DateUtilities.now() + TimeZone.getDefault().getOffset(DateUtilities.now());
+        // FIXME: doesnt respect timezones, see story 17443653
+        if(task.hasDueDate()) {
+            if(task.hasDueTime()) {
+                long estimatedTime = task.getValue(Task.ESTIMATED_SECONDS)  * 1000;
+                if(estimatedTime <= 0)
+                    estimatedTime = DEFAULT_CAL_TIME;
+                values.put("dtstart", dueDate - estimatedTime);
+                values.put("dtend", dueDate);
+                // setting a duetime to a previously timeless event requires explicitly setting allDay=0
+                values.put("allDay", "0");
+            } else {
+                values.put("dtstart", tzCorrectedDueDate);
+                values.put("dtend", tzCorrectedDueDate);
+                values.put("allDay", "1");
+            }
+        } else {
+            values.put("dtstart", tzCorrectedDueDateNow);
+            values.put("dtend", tzCorrectedDueDateNow);
+            values.put("allDay", "1");
         }
     }
 }

--- a/astrid/plugin-src/com/todoroo/astrid/repeats/RepeatTaskCompleteListener.java
+++ b/astrid/plugin-src/com/todoroo/astrid/repeats/RepeatTaskCompleteListener.java
@@ -9,8 +9,11 @@ import java.util.List;
 import java.util.TimeZone;
 
 import android.content.BroadcastReceiver;
+import android.content.ContentResolver;
+import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
 
 import com.google.ical.iter.RecurrenceIterator;
 import com.google.ical.iter.RecurrenceIteratorFactory;
@@ -20,14 +23,17 @@ import com.google.ical.values.DateValueImpl;
 import com.google.ical.values.Frequency;
 import com.google.ical.values.RRule;
 import com.google.ical.values.WeekdayNum;
+import com.timsu.astrid.R;
 import com.todoroo.andlib.service.Autowired;
 import com.todoroo.andlib.service.ContextManager;
 import com.todoroo.andlib.service.DependencyInjectionService;
 import com.todoroo.andlib.utility.DateUtilities;
+import com.todoroo.andlib.utility.Preferences;
 import com.todoroo.astrid.actfm.sync.ActFmPreferenceService;
 import com.todoroo.astrid.api.AstridApiConstants;
 import com.todoroo.astrid.core.PluginServices;
 import com.todoroo.astrid.data.Task;
+import com.todoroo.astrid.gcal.GCalHelper;
 import com.todoroo.astrid.service.StatisticsConstants;
 import com.todoroo.astrid.service.StatisticsService;
 import com.todoroo.astrid.utility.Flags;
@@ -46,8 +52,7 @@ public class RepeatTaskCompleteListener extends BroadcastReceiver {
         if(taskId == -1)
             return;
 
-        Task task = PluginServices.getTaskService().fetchById(taskId, Task.ID, Task.RECURRENCE,
-                Task.DUE_DATE, Task.FLAGS, Task.HIDE_UNTIL, Task.REMOTE_ID, Task.COMPLETION_DATE);
+        Task task = PluginServices.getTaskService().fetchById(taskId, Task.PROPERTIES);
         if(task == null || !task.isCompleted())
             return;
 
@@ -90,11 +95,21 @@ public class RepeatTaskCompleteListener extends BroadcastReceiver {
             clone.setValue(Task.ELAPSED_SECONDS, 0);
             clone.setValue(Task.REMINDER_SNOOZE, 0L);
             clone.setValue(Task.REMINDER_LAST, 0L);
+
+            boolean gcalCreateEventEnabled = Preferences.getStringValue(R.string.gcal_p_default) != null &&
+                                            !Preferences.getStringValue(R.string.gcal_p_default).equals("-1");
+            if (gcalCreateEventEnabled) {
+                ContentResolver cr = ContextManager.getContext().getContentResolver();
+                Uri calendarUri = GCalHelper.createTaskEvent(clone, cr, new ContentValues());
+                clone.setValue(Task.CALENDAR_URI, calendarUri.toString());
+            }
             PluginServices.getTaskService().save(clone);
 
             // clear recurrence from completed task so it can be re-completed
             task.setValue(Task.RECURRENCE, ""); //$NON-NLS-1$
             task.setValue(Task.DETAILS_DATE, 0L);
+
+            GCalHelper.deleteTaskEvent(task);
             PluginServices.getTaskService().save(task);
 
             // send a broadcast

--- a/astrid/res/values-de/strings.xml
+++ b/astrid/res/values-de/strings.xml
@@ -651,6 +651,8 @@
   <!-- Preference Window Title -->
   <string name="EPr_title">Astrid: Einstellungen</string>
 
+  <string name="EPr_deactivated">deaktiviert</string>
+
   <!-- Preference Category: Appearance Title -->
   <string name="EPr_appearance_header">Erscheinungsbild</string>
   

--- a/astrid/res/values/keys.xml
+++ b/astrid/res/values/keys.xml
@@ -247,6 +247,11 @@
   <!-- default Add To Calendar setting (corresponds to entry in gcal_TEA_addToCalendar) -->
   <string name="p_default_addtocalendar_key">p_def_addtocalendar</string>
   
+  <string-array name="EPr_default_addtocalendar_values">
+    <!-- addtocalendar: labels that map EPr_default_addtocalendar items to calendar selection in settings. -->
+    <item>-1</item>
+  </string-array>
+
   <!-- ============================================================ SYNC == -->
   
     <string-array name="sync_SPr_interval_values">

--- a/astrid/res/values/strings-core.xml
+++ b/astrid/res/values/strings-core.xml
@@ -361,6 +361,8 @@
     
   <!-- Preference Window Title -->
   <string name="EPr_title">Astrid: Settings</string>
+  
+  <string name="EPr_deactivated">deactivated</string>
 
   <!-- Preference Category: Appearance Title -->
   <string name="EPr_appearance_header">Appearance</string>
@@ -383,65 +385,6 @@
   <string name="EPr_theme_desc">Currently: %s</string>  
   <!-- Preference: Theme Description (android 1.6) -->
   <string name="EPr_theme_desc_unsupported">Setting requires Android 2.0+</string>
-  
-  <!-- Preference Category: Defaults Title -->
-  <string name="EPr_defaults_header">New Task Defaults</string>
-  
-  <!-- Preference: Default Urgency Title -->
-  <string name="EPr_default_urgency_title">Default Urgency</string>
-  <!-- Preference: Default Urgency Description (%s => setting) -->
-  <string name="EPr_default_urgency_desc">Currently: %s</string>
-  
-  <!-- Preference: Default Importance Title -->
-  <string name="EPr_default_importance_title">Default Importance</string>
-  <!-- Preference: Default Importance Description (%s => setting) -->
-  <string name="EPr_default_importance_desc">Currently: %s</string>
-  
-  <!-- Preference: Default Hide Until Title -->
-  <string name="EPr_default_hideUntil_title">Default Hide Until</string>
-  <!-- Preference: Default Hide Until Description (%s => setting) -->
-  <string name="EPr_default_hideUntil_desc">Currently: %s</string>
-  
-  <!-- Preference: Default Reminders Title -->
-  <string name="EPr_default_reminders_title">Default Reminders</string>
-  <!-- Preference: Default Reminders Description (%s => setting) -->
-  <string name="EPr_default_reminders_desc">Currently: %s</string>
-  
-  <!-- Preference: Default Add To Calendar Title -->
-  <string name="EPr_default_addtocalendar_title">Default Add To Calendar</string>
-  
-  <string-array name="EPr_default_importance">
-      <!-- importance: labels for "Task Defaults" preference item. -->
-      <item>!!!! (Highest)</item>
-      <item>!!!</item>
-      <item>!!</item>
-      <item>! (Lowest)</item>
-  </string-array>
-  
-  <string-array name="EPr_default_urgency">
-      <!-- urgency: labels for "Task Defaults" preference item. -->
-      <item>No Deadline</item>
-      <item>Today</item>
-      <item>Tomorrow</item>
-      <item>Day After Tomorrow</item>
-      <item>Next Week</item>
-  </string-array>
-  
-  <string-array name="EPr_default_hideUntil">
-      <!-- hideUntil: labels for "Task Defaults" preference item. -->
-      <item>Don\'t hide</item>
-      <item>Task is due</item>
-      <item>Day before due</item>
-      <item>Week before due</item>
-  </string-array>
-  
-  <string-array name="EPr_default_reminders">
-      <!-- reminders: labels for "Task Defaults" preference item. -->
-      <item>No deadline reminders</item>
-      <item>At deadline</item>
-      <item>When overdue</item>
-      <item>At deadline or overdue</item>
-  </string-array>
     
   <string-array name="EPr_themes">
     <!-- theme_settings: labels for Theme preference menu -->

--- a/astrid/res/values/strings-defaults.xml
+++ b/astrid/res/values/strings-defaults.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+   <!-- Preference Category: Defaults Title -->
+  <string name="EPr_defaults_header">New Task Defaults</string>
+  
+  <!-- Preference: Default Urgency Title -->
+  <string name="EPr_default_urgency_title">Default Urgency</string>
+  <!-- Preference: Default Urgency Description (%s => setting) -->
+  <string name="EPr_default_urgency_desc">Currently: %s</string>
+  
+  <!-- Preference: Default Importance Title -->
+  <string name="EPr_default_importance_title">Default Importance</string>
+  <!-- Preference: Default Importance Description (%s => setting) -->
+  <string name="EPr_default_importance_desc">Currently: %s</string>
+  
+  <!-- Preference: Default Hide Until Title -->
+  <string name="EPr_default_hideUntil_title">Default Hide Until</string>
+  <!-- Preference: Default Hide Until Description (%s => setting) -->
+  <string name="EPr_default_hideUntil_desc">Currently: %s</string>
+  
+  <!-- Preference: Default Reminders Title -->
+  <string name="EPr_default_reminders_title">Default Reminders</string>
+  <!-- Preference: Default Reminders Description (%s => setting) -->
+  <string name="EPr_default_reminders_desc">Currently: %s</string>
+  
+  <!-- Preference: Default Add To Calendar Title -->
+  <string name="EPr_default_addtocalendar_title">Default Add To Calendar</string>
+  <!-- Preference: Default Add To Calendar Setting Description (disabled) -->
+  <string name="EPr_default_addtocalendar_desc_disabled">New tasks will not create an event in the Google Calendar</string>
+  <!-- Preference: Default Add To Calendar Setting Description (%s => setting) -->
+  <string name="EPr_default_addtocalendar_desc">New tasks will be in the calendar: \"%s\"</string>
+  
+  <string-array name="EPr_default_importance">
+      <!-- importance: labels for "Task Defaults" preference item. -->
+      <item>!!!! (Highest)</item>
+      <item>!!!</item>
+      <item>!!</item>
+      <item>! (Lowest)</item>
+  </string-array>
+  
+  <string-array name="EPr_default_urgency">
+      <!-- urgency: labels for "Task Defaults" preference item. -->
+      <item>No Deadline</item>
+      <item>Today</item>
+      <item>Tomorrow</item>
+      <item>Day After Tomorrow</item>
+      <item>Next Week</item>
+  </string-array>
+  
+  <string-array name="EPr_default_hideUntil">
+      <!-- hideUntil: labels for "Task Defaults" preference item. -->
+      <item>Don\'t hide</item>
+      <item>Task is due</item>
+      <item>Day before due</item>
+      <item>Week before due</item>
+  </string-array>
+  
+  <string-array name="EPr_default_reminders">
+      <!-- reminders: labels for "Task Defaults" preference item. -->
+      <item>No deadline reminders</item>
+      <item>At deadline</item>
+      <item>When overdue</item>
+      <item>At deadline or overdue</item>
+  </string-array>
+  
+    <string-array name="EPr_default_addtocalendar">
+      <!-- addtocalendar: labels for "Task Defaults" preference item. -->
+      <item>@string/EPr_deactivated</item>
+  </string-array>      
+</resources>

--- a/astrid/res/xml/preferences_defaults.xml
+++ b/astrid/res/xml/preferences_defaults.xml
@@ -27,4 +27,9 @@
         android:title="@string/rmd_EPr_defaultRemind_title"
         android:entries="@array/EPr_reminder_random"
         android:entryValues="@array/EPr_reminder_random_hours" />
+    <com.todoroo.astrid.ui.MultilineListPreference
+        android:title="@string/EPr_default_addtocalendar_title"
+        android:key="@string/gcal_p_default"
+        android:entries="@array/EPr_default_addtocalendar"
+        android:entryValues="@array/EPr_default_addtocalendar_values" />
 </PreferenceScreen>

--- a/astrid/src/com/todoroo/astrid/activity/TaskEditActivity.java
+++ b/astrid/src/com/todoroo/astrid/activity/TaskEditActivity.java
@@ -332,7 +332,6 @@ public final class TaskEditActivity extends TabActivity {
                     (LinearLayout) findViewById(R.id.addons_urgency)));
             LinearLayout alarmsAddons = (LinearLayout) findViewById(R.id.addons_alarms);
             LinearLayout moreAddons = (LinearLayout) findViewById(R.id.addons_more);
-            controls.add(new GCalControlSet(TaskEditActivity.this, moreAddons));
 
 
             try {
@@ -357,6 +356,7 @@ public final class TaskEditActivity extends TabActivity {
 
             controls.add(new TimerControlSet(TaskEditActivity.this, moreAddons));
             controls.add(new AlarmControlSet(TaskEditActivity.this, alarmsAddons));
+            controls.add(new GCalControlSet(TaskEditActivity.this, moreAddons));
 
             if(!Constants.MARKET_DISABLED && !addOnService.hasPowerPack()) {
                 // show add-on help if necessary
@@ -486,6 +486,9 @@ public final class TaskEditActivity extends TabActivity {
 
     /** Save task model from values in UI components */
     private void save(boolean onPause) {
+        if(title.getText().length() > 0)
+            model.setValue(Task.DELETION_DATE, 0L);
+
         StringBuilder toast = new StringBuilder();
         synchronized(controls) {
             for(TaskEditControlSet controlSet : controls) {
@@ -494,9 +497,6 @@ public final class TaskEditActivity extends TabActivity {
                     toast.append('\n').append(toastText);
             }
         }
-
-        if(title.getText().length() > 0)
-            model.setValue(Task.DELETION_DATE, 0L);
 
         taskService.save(model);
         if(title.getText().length() == 0)

--- a/astrid/src/com/todoroo/astrid/activity/TaskListActivity.java
+++ b/astrid/src/com/todoroo/astrid/activity/TaskListActivity.java
@@ -87,6 +87,7 @@ import com.todoroo.astrid.dao.Database;
 import com.todoroo.astrid.dao.TaskDao.TaskCriteria;
 import com.todoroo.astrid.data.Metadata;
 import com.todoroo.astrid.data.Task;
+import com.todoroo.astrid.gcal.GCalHelper;
 import com.todoroo.astrid.helper.MetadataHelper;
 import com.todoroo.astrid.helper.TaskListContextMenuExtensionLoader;
 import com.todoroo.astrid.helper.TaskListContextMenuExtensionLoader.ContextMenuItem;
@@ -836,6 +837,14 @@ public class TaskListActivity extends ListActivity implements OnScrollListener,
                 title = title.trim();
             Task task = createWithValues(filter.valuesForNewTasks,
                     title, taskService, metadataService);
+
+            boolean gcalCreateEventEnabled = Preferences.getStringValue(R.string.gcal_p_default) != null &&
+                                             !Preferences.getStringValue(R.string.gcal_p_default).equals("-1");
+            if (title.length()>0 && gcalCreateEventEnabled) {
+                Uri calendarUri = GCalHelper.createTaskEvent(task, getContentResolver(), new ContentValues());
+                task.setValue(Task.CALENDAR_URI, calendarUri.toString());
+                taskService.save(task);
+            }
 
             TextView quickAdd = (TextView)findViewById(R.id.quickAddText);
             quickAdd.setText(""); //$NON-NLS-1$


### PR DESCRIPTION
Implemented gcal-default-setting and fixed some bugs with gcal-integration (timezone-bug, estimated time, adding duetime, changing task-details). This setting is not regarded for sync, as the webservices usually offer their own gcal-integration like gtasks, producteev.

Please wait for Malika checking it thoroughly before you integrate this pull-request.
