### PR TITLE
Fixed the Blade-filterlist bug.

### DIFF
--- a/api/src/com/todoroo/astrid/api/AstridFilterExposer.java
+++ b/api/src/com/todoroo/astrid/api/AstridFilterExposer.java
@@ -1,0 +1,13 @@
+/**
+ * See the file "LICENSE" for the full license governing this code.
+ */
+package com.todoroo.astrid.api;
+
+/**
+ * Common interface for Astrids filter-exposers to provide their {@link FilterListitem}-instances.
+ *
+ * @author Arne Jans
+ */
+public interface AstridFilterExposer {
+    public FilterListItem[] getFilters();
+}

--- a/astrid/src/com/todoroo/astrid/utility/Constants.java
+++ b/astrid/src/com/todoroo/astrid/utility/Constants.java
@@ -37,6 +37,12 @@ public final class Constants {
     public static final boolean DEBUG = false;
 
     /**
+     * Whether to turn on debugging for an emulated zte blade error (in the FilterReceiver)
+     * Only for testing purposes. Remember to set this to false for a standard release!
+     */
+    public static final boolean DEBUG_BLADE = false;
+
+    /**
      * Astrid Help URL
      */
     public static final String HELP_URL = "http://weloveastrid.com/help-user-guide-astrid-v3/active-tasks/"; //$NON-NLS-1$


### PR DESCRIPTION
I implemented the workaround as Tim suggested by introducing the new interface
AstridFilterExposer and used it in the FilterAdapter-class. Additionally, I
had to introduce a fallback resultReceiver that is called after the last
filterexposer finished and checks if the filterlist-screen is empty. In this
case it uses a pre-fetched lists of Astrids registered receivers for filters
and uses the new interface on them to get the FilterListItem-instances.
