### PR TITLE
Added a field for tracking the last gtasks sync date of a particular task

### DIFF
--- a/api/src/com/todoroo/astrid/data/Task.java
+++ b/api/src/com/todoroo/astrid/data/Task.java
@@ -160,6 +160,10 @@ public final class Task extends RemoteModel {
     public static final LongProperty LAST_SYNC = new LongProperty(
             TABLE, "lastSync");
 
+    /** Last Sync date with gtasks */
+    public static final LongProperty LAST_SYNC_GTASKS = new LongProperty(
+            TABLE, "lastSyncGtasks");
+
     /** List of all properties for this model */
     public static final Property<?>[] PROPERTIES = generateProperties(Task.class);
 

--- a/api/src/com/todoroo/astrid/sync/SyncMetadataService.java
+++ b/api/src/com/todoroo/astrid/sync/SyncMetadataService.java
@@ -97,11 +97,16 @@ abstract public class SyncMetadataService<TYPE extends SyncContainer> {
         if(lastSyncDate == 0)
             tasks = taskDao.query(Query.select(Task.ID).where(Criterion.none));
         else
-            tasks = taskDao.query(Query.select(Task.ID).where(Criterion.and(
-                    Task.MODIFICATION_DATE.gt(lastSyncDate),
-                    Task.LAST_SYNC.lte(lastSyncDate))).orderBy(Order.asc(Task.ID)));
+            tasks = taskDao.query(Query.select(Task.ID).where(getLocallyUpdatedCriterion(lastSyncDate))
+                                                       .orderBy(Order.asc(Task.ID)));
 
         return joinWithMetadata(tasks, true, properties);
+    }
+
+    protected Criterion getLocallyUpdatedCriterion(long lastSyncDate) {
+        return Criterion.and(
+                Task.MODIFICATION_DATE.gt(lastSyncDate),
+                Task.LAST_SYNC.lte(lastSyncDate));
     }
 
     private TodorooCursor<Task> joinWithMetadata(TodorooCursor<Task> tasks,

--- a/astrid/plugin-src/com/todoroo/astrid/gtasks/GtasksMetadataService.java
+++ b/astrid/plugin-src/com/todoroo/astrid/gtasks/GtasksMetadataService.java
@@ -74,6 +74,13 @@ public final class GtasksMetadataService extends SyncMetadataService<GtasksTaskC
         return GtasksMetadata.ID.neq(""); //$NON-NLS-1$
     }
 
+    @Override
+    protected Criterion getLocallyUpdatedCriterion(long lastSyncDate) {
+        return Criterion.and(
+                Task.MODIFICATION_DATE.gt(lastSyncDate),
+                Task.LAST_SYNC_GTASKS.lte(lastSyncDate));
+    }
+
     // --- list iterating helpers
 
 

--- a/astrid/plugin-src/com/todoroo/astrid/gtasks/sync/GtasksSyncOnSaveService.java
+++ b/astrid/plugin-src/com/todoroo/astrid/gtasks/sync/GtasksSyncOnSaveService.java
@@ -253,7 +253,7 @@ public final class GtasksSyncOnSaveService {
         }
 
         task.setValue(Task.MODIFICATION_DATE, DateUtilities.now());
-        task.setValue(Task.LAST_SYNC, DateUtilities.now());
+        task.setValue(Task.LAST_SYNC_GTASKS, DateUtilities.now() + 1000);
         Flags.set(Flags.GTASKS_SUPPRESS_SYNC);
         taskDao.saveExisting(task);
     }

--- a/astrid/src/com/todoroo/astrid/dao/Database.java
+++ b/astrid/src/com/todoroo/astrid/dao/Database.java
@@ -37,7 +37,7 @@ public class Database extends AbstractDatabase {
      * Database version number. This variable must be updated when database
      * tables are updated, as it determines whether a database needs updating.
      */
-    public static final int VERSION = 17;
+    public static final int VERSION = 18;
 
     /**
      * Database name (must be unique)
@@ -223,6 +223,12 @@ public class Database extends AbstractDatabase {
         case 16: try {
             database.execSQL("ALTER TABLE " + Task.TABLE.name + " ADD " +
                     Task.CREATOR_ID.accept(visitor, null) + " DEFAULT 0");
+        } catch (SQLiteException e) {
+            Log.e("astrid", "db-upgrade-" + oldVersion + "-" + newVersion, e);
+        }
+        case 17: try {
+            database.execSQL("ALTER TABLE " + Task.TABLE.name + " ADD " +
+                    Task.LAST_SYNC_GTASKS.accept(visitor, null) + " DEFAULT 0");
         } catch (SQLiteException e) {
             Log.e("astrid", "db-upgrade-" + oldVersion + "-" + newVersion, e);
         }


### PR DESCRIPTION
Added a field for tracking the last gtasks sync date of a particular task. Fixes a bug that could lose changes when syncing with two services at once.
