### PR TITLE
EditPeopleControlSet bugs

### DIFF
--- a/astrid/src/com/todoroo/astrid/activity/TaskEditFragment.java
+++ b/astrid/src/com/todoroo/astrid/activity/TaskEditFragment.java
@@ -859,7 +859,7 @@ ViewPager.OnPageChangeListener, EditNoteActivity.UpdatesChangedListener {
 
     public boolean onKeyDown(int keyCode) {
         if (keyCode == KeyEvent.KEYCODE_BACK) {
-            if (title.getText().length() == 0)
+            if (title.getText().length() == 0 || !peopleControlSet.hasLoadedUI())
                 discardButtonClick();
             else
                 saveButtonClick();


### PR DESCRIPTION
There were some concurrency problems with EditPeopleControlSet. Specifically, it was possible for saveSharingSettings to be called before the spinner was loaded, causing a crash. This commit fixes that by a) checking that the background thread has finished loading the ui before trying to access the list adapter and b) finer-grained catching of JSON exceptions to ensure that a list adapter is always created.

Just wanted a quick code review for sanity's sake!
