### PR TITLE
Realtime task counts

### DIFF
--- a/api/src/com/todoroo/astrid/api/Filter.java
+++ b/api/src/com/todoroo/astrid/api/Filter.java
@@ -121,6 +121,38 @@ public class Filter extends FilterListItem {
         return 0;
     }
 
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result
+                + ((sqlQuery == null) ? 0 : sqlQuery.hashCode());
+        result = prime * result + ((title == null) ? 0 : title.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Filter other = (Filter) obj;
+        if (sqlQuery == null) {
+            if (other.sqlQuery != null)
+                return false;
+        } else if (!sqlQuery.equals(other.sqlQuery))
+            return false;
+        if (title == null) {
+            if (other.title != null)
+                return false;
+        } else if (!title.equals(other.title))
+            return false;
+        return true;
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/astrid/src/com/todoroo/astrid/activity/TaskListActivity.java
+++ b/astrid/src/com/todoroo/astrid/activity/TaskListActivity.java
@@ -457,6 +457,20 @@ public class TaskListActivity extends AstridActivity implements MainMenuListener
         }
     }
 
+    public void incrementFilterCount(Filter filter) {
+        FilterListFragment flf = getFilterListFragment();
+        if (flf != null) {
+            flf.adapter.incrementFilterCount(filter);
+        }
+    }
+
+    public void decrementFilterCount(Filter filter) {
+        FilterListFragment flf = getFilterListFragment();
+        if (flf != null) {
+            flf.adapter.decrementFilterCount(filter);
+        }
+    }
+
     @Override
     public void mainMenuItemSelected(int item, Intent customIntent) {
         TaskListFragment tlf = getTaskListFragment();

--- a/astrid/src/com/todoroo/astrid/activity/TaskListFragment.java
+++ b/astrid/src/com/todoroo/astrid/activity/TaskListFragment.java
@@ -1054,6 +1054,19 @@ public class TaskListFragment extends ListFragment implements OnScrollListener,
 
     protected void onTaskDelete(@SuppressWarnings("unused") Task task) {
         // hook
+        decrementFilterCount();
+    }
+
+    public void incrementFilterCount() {
+        if (getActivity() instanceof TaskListActivity) {
+            ((TaskListActivity) getActivity()).incrementFilterCount(filter);
+        }
+    }
+
+    public void decrementFilterCount() {
+        if (getActivity() instanceof TaskListActivity) {
+            ((TaskListActivity) getActivity()).decrementFilterCount(filter);
+        }
     }
 
     @Override

--- a/astrid/src/com/todoroo/astrid/adapter/FilterAdapter.java
+++ b/astrid/src/com/todoroo/astrid/adapter/FilterAdapter.java
@@ -93,7 +93,7 @@ public class FilterAdapter extends ArrayAdapter<Filter> {
     private final boolean selectable;
 
     /** Pattern for matching filter counts in listing titles */
-    private final Pattern countPattern = Pattern.compile(".* \\((\\d+\\))$"); //$NON-NLS-1$
+    private final Pattern countPattern = Pattern.compile(".* \\((\\d+)\\)$"); //$NON-NLS-1$
 
     private int mSelectedIndex;
 
@@ -150,6 +150,7 @@ public class FilterAdapter extends ArrayAdapter<Filter> {
                             size = Integer.parseInt(countString);
                         } catch (NumberFormatException e) {
                             // Count manually
+                            e.printStackTrace();
                         }
                     }
 

--- a/astrid/src/com/todoroo/astrid/adapter/FilterAdapter.java
+++ b/astrid/src/com/todoroo/astrid/adapter/FilterAdapter.java
@@ -3,10 +3,13 @@
  */
 package com.todoroo.astrid.adapter;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import android.app.Activity;
 import android.app.PendingIntent;
@@ -89,7 +92,12 @@ public class FilterAdapter extends ArrayAdapter<Filter> {
     /** whether rows are selectable */
     private final boolean selectable;
 
+    /** Pattern for matching filter counts in listing titles */
+    private final Pattern countPattern = Pattern.compile(".* \\((\\d+\\))$"); //$NON-NLS-1$
+
     private int mSelectedIndex;
+
+    private final HashMap<Filter, Integer> filterCounts;
 
     // Previous solution involved a queue of filters and a filterSizeLoadingThread. The filterSizeLoadingThread had
     // a few problems: how to make sure that the thread is resumed when the controlling activity is resumed, and
@@ -116,6 +124,7 @@ public class FilterAdapter extends ArrayAdapter<Filter> {
         this.layout = rowLayout;
         this.skipIntentFilters = skipIntentFilters;
         this.selectable = selectable;
+        this.filterCounts = new HashMap<Filter, Integer>();
 
         if (activity instanceof AstridActivity && ((AstridActivity) activity).getFragmentLayout() != AstridActivity.LAYOUT_SINGLE)
             filterStyle = R.style.TextAppearance_FLA_Filter_Tablet;
@@ -133,11 +142,24 @@ public class FilterAdapter extends ArrayAdapter<Filter> {
             @Override
             public void run() {
                 try {
-                    if(filter.listingTitle.matches(".* \\(\\d+\\)$")) //$NON-NLS-1$
-                        return;
-                    int size = taskService.countTasks(filter);
-                    filter.listingTitle = filter.listingTitle + (" (" + //$NON-NLS-1$
-                        size + ")"); //$NON-NLS-1$
+                    int size = -1;
+                    Matcher m = countPattern.matcher(filter.listingTitle);
+                    if(m.find()) {
+                        String countString = m.group(1);
+                        try {
+                            size = Integer.parseInt(countString);
+                        } catch (NumberFormatException e) {
+                            // Count manually
+                        }
+                    }
+
+                    if (size < 0) {
+                        size = taskService.countTasks(filter);
+                        filter.listingTitle = filter.listingTitle + (" (" + //$NON-NLS-1$
+                                size + ")"); //$NON-NLS-1$
+                    }
+
+                    filterCounts.put(filter, size);
                     activity.runOnUiThread(new Runnable() {
                         public void run() {
                             notifyDataSetInvalidated();
@@ -167,6 +189,24 @@ public class FilterAdapter extends ArrayAdapter<Filter> {
         mSelectedIndex = lastSelected;
     }
 
+    public int adjustFilterCount(Filter filter, int delta) {
+        int filterCount = 0;
+        if (filterCounts.containsKey(filter)) {
+            filterCount = filterCounts.get(filter);
+        }
+        int newCount = Math.max(filterCount + delta, 0);
+        filterCounts.put(filter, newCount);
+        notifyDataSetInvalidated();
+        return newCount;
+    }
+
+    public int incrementFilterCount(Filter filter) {
+        return adjustFilterCount(filter, 1);
+    }
+
+    public int decrementFilterCount(Filter filter) {
+        return adjustFilterCount(filter, -1);
+    }
 
     /**
      * Create or reuse a view
@@ -434,11 +474,25 @@ public class FilterAdapter extends ArrayAdapter<Filter> {
         }
 
         // title / size
-        if(filter.listingTitle.matches(".* \\(\\d+\\)$")) { //$NON-NLS-1$
+        if(filterCounts.containsKey(filter) || filter.listingTitle.matches(".* \\(\\d+\\)$")) { //$NON-NLS-1$
             viewHolder.size.setVisibility(View.VISIBLE);
-            viewHolder.size.setText(filter.listingTitle.substring(filter.listingTitle.lastIndexOf('(') + 1,
-                    filter.listingTitle.length() - 1));
-            viewHolder.name.setText(filter.listingTitle.substring(0, filter.listingTitle.lastIndexOf(' ')));
+            String count;
+            if (filterCounts.containsKey(filter)) {
+                count = filterCounts.get(filter).toString();
+            } else {
+                count = filter.listingTitle.substring(filter.listingTitle.lastIndexOf('(') + 1,
+                        filter.listingTitle.length() - 1);
+            }
+            viewHolder.size.setText(count);
+
+            String title;
+            int listingTitleSplit = filter.listingTitle.lastIndexOf(' ');
+            if (listingTitleSplit > 0) {
+                title = filter.listingTitle.substring(0, listingTitleSplit);
+            } else {
+                title = filter.listingTitle;
+            }
+            viewHolder.name.setText(title);
         } else {
             viewHolder.name.setText(filter.listingTitle);
             viewHolder.size.setVisibility(View.GONE);

--- a/astrid/src/com/todoroo/astrid/ui/QuickAddBar.java
+++ b/astrid/src/com/todoroo/astrid/ui/QuickAddBar.java
@@ -321,6 +321,8 @@ public class QuickAddBar extends LinearLayout {
                 }
             }
 
+            fragment.incrementFilterCount();
+
             StatisticsService.reportEvent(StatisticsConstants.TASK_CREATED_TASKLIST);
             return task;
         } catch (Exception e) {


### PR DESCRIPTION
Makes task count in filter list for the current filter update when tasks are added or deleted.

Tim, I think this is done but I'm pull requesting it so you can take a look and tell me if there might be clever ways to update ALL the counts in the filter list (i.e. if a task fits multiple filters) rather than just the current filter.
