### PR TITLE
Gtasks sync fixes

### DIFF
--- a/api/src/com/todoroo/andlib/data/AbstractModel.java
+++ b/api/src/com/todoroo/andlib/data/AbstractModel.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import android.content.ContentValues;
@@ -404,9 +405,10 @@ public abstract class AbstractModel implements Parcelable, Cloneable {
     private void restoreTransitories(ContentValues cv) {
         if (transitoryData == null)
             transitoryData = new HashMap<String, Object>();
-        Set<String> keys = cv.keySet();
+        Set<Entry<String, Object>> entries = cv.valueSet();
         Set<String> keysToRemove = new HashSet<String>();
-        for (String key : keys) {
+        for (Entry<String, Object> entry: entries) {
+            String key = entry.getKey();
             if (key.startsWith(RETAIN_TRANSITORY_PREFIX)) {
                 String newKey = key.substring(RETAIN_TRANSITORY_PREFIX.length());
                 Object value = cv.get(key);

--- a/api/src/com/todoroo/andlib/data/AbstractModel.java
+++ b/api/src/com/todoroo/andlib/data/AbstractModel.java
@@ -11,6 +11,8 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
 
 import android.content.ContentValues;
 import android.os.Parcel;
@@ -47,6 +49,9 @@ public abstract class AbstractModel implements Parcelable, Cloneable {
 
     /** sentinel for objects without an id */
     public static final long NO_ID = 0;
+
+    /** prefix for transitories retained in content values */
+    public static final String RETAIN_TRANSITORY_PREFIX = "retain-trans-"; //$NON-NLS-1$
 
     // --- abstract methods
 
@@ -313,6 +318,7 @@ public abstract class AbstractModel implements Parcelable, Cloneable {
     public synchronized <TYPE> void mergeWith(ContentValues other) {
         if (setValues == null)
             setValues = new ContentValues();
+        restoreTransitories(other);
         setValues.putAll(other);
     }
 
@@ -369,6 +375,74 @@ public abstract class AbstractModel implements Parcelable, Cloneable {
         if (transitoryData == null)
             return null;
         return transitoryData.remove(key);
+    }
+
+    /**
+     * Move transitory values (those that can be saved) to setValues,
+     * to be restored later. This is useful for the api daos that go
+     * through the content provider
+     */
+    public synchronized void retainTransitories() {
+        if (transitoryData == null)
+            return;
+        if (setValues == null)
+            setValues = new ContentValues();
+        Set<String> keys = transitoryData.keySet();
+        for (String key : keys) {
+            String newKey = RETAIN_TRANSITORY_PREFIX + key;
+            Object value = transitoryData.get(key);
+            putObjectInContentValues(newKey, value, setValues);
+        }
+    }
+
+    /**
+     * Read keys from ContentValues. Remove those that match the
+     * RETAIN_TRANSITORY_PREFIX pattern and set those values
+     * on transitory data
+     * @param cv
+     */
+    private void restoreTransitories(ContentValues cv) {
+        if (transitoryData == null)
+            transitoryData = new HashMap<String, Object>();
+        Set<String> keys = cv.keySet();
+        Set<String> keysToRemove = new HashSet<String>();
+        for (String key : keys) {
+            if (key.startsWith(RETAIN_TRANSITORY_PREFIX)) {
+                String newKey = key.substring(RETAIN_TRANSITORY_PREFIX.length());
+                Object value = cv.get(key);
+                transitoryData.put(newKey, value);
+                keysToRemove.add(key);
+            }
+        }
+
+        for (String key : keysToRemove) {
+            cv.remove(key);
+        }
+    }
+
+    /**
+     * If value is of a type that is puttable in ContentValues, cast and put it
+     * @param key
+     * @param value
+     * @param cv
+     */
+    private void putObjectInContentValues(String key, Object value, ContentValues cv) {
+        if (value instanceof Boolean)
+            cv.put(key, (Boolean) value);
+        if (value instanceof Byte)
+            cv.put(key, (Byte) value);
+        if (value instanceof Double)
+            cv.put(key, (Double) value);
+        if (value instanceof Float)
+            cv.put(key, (Float) value);
+        if (value instanceof Integer)
+            cv.put(key, (Integer) value);
+        if (value instanceof Long)
+            cv.put(key, (Long) value);
+        if (value instanceof Short)
+            cv.put(key, (Short) value);
+        if (value instanceof String)
+            cv.put(key, (String) value);
     }
 
 

--- a/api/src/com/todoroo/andlib/data/ContentResolverDao.java
+++ b/api/src/com/todoroo/andlib/data/ContentResolverDao.java
@@ -91,12 +91,17 @@ public class ContentResolverDao<TYPE extends AbstractModel> {
      * @return true if data was written to the db, false otherwise
      */
     public boolean save(TYPE model) {
+        boolean retainedTransitories = false;
         if(model.isSaved()) {
             if(model.getSetValues() == null)
                 return false;
+            model.retainTransitories();
+            retainedTransitories = true;
             if(cr.update(uriWithId(model.getId()), model.getSetValues(), null, null) != 0)
                 return true;
         }
+        if (!retainedTransitories)
+            model.retainTransitories();
         Uri uri = cr.insert(baseUri, model.getMergedValues());
         long id = Long.parseLong(uri.getLastPathSegment());
         model.setId(id);

--- a/api/src/com/todoroo/andlib/data/ContentResolverDao.java
+++ b/api/src/com/todoroo/andlib/data/ContentResolverDao.java
@@ -2,8 +2,10 @@ package com.todoroo.andlib.data;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Set;
 
 import android.content.ContentResolver;
+import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
@@ -13,6 +15,7 @@ import com.todoroo.andlib.service.Autowired;
 import com.todoroo.andlib.service.DependencyInjectionService;
 import com.todoroo.andlib.sql.Criterion;
 import com.todoroo.andlib.sql.Query;
+import com.todoroo.andlib.utility.AndroidUtilities;
 
 
 /**
@@ -95,18 +98,31 @@ public class ContentResolverDao<TYPE extends AbstractModel> {
         if(model.isSaved()) {
             if(model.getSetValues() == null)
                 return false;
-            model.retainTransitories();
+            writeTransitoriesToModelContentValues(model);
             retainedTransitories = true;
             if(cr.update(uriWithId(model.getId()), model.getSetValues(), null, null) != 0)
                 return true;
         }
         if (!retainedTransitories)
-            model.retainTransitories();
+            writeTransitoriesToModelContentValues(model);
         Uri uri = cr.insert(baseUri, model.getMergedValues());
         long id = Long.parseLong(uri.getLastPathSegment());
         model.setId(id);
         model.markSaved();
         return true;
+    }
+
+    private void writeTransitoriesToModelContentValues(AbstractModel model) {
+        Set<String> keys = model.getAllTransitoryKeys();
+        if (keys != null) {
+            ContentValues transitories = new ContentValues();
+            for (String key : keys) {
+                String newKey = AbstractModel.RETAIN_TRANSITORY_PREFIX + key;
+                Object value = model.getTransitory(key);
+                AndroidUtilities.putInto(transitories, newKey, value, false);
+            }
+            model.mergeWith(transitories);
+        }
     }
 
     /**

--- a/api/src/com/todoroo/andlib/utility/AndroidUtilities.java
+++ b/api/src/com/todoroo/andlib/utility/AndroidUtilities.java
@@ -150,16 +150,24 @@ public class AndroidUtilities {
      * @param key
      * @param value
      */
-    public static void putInto(ContentValues target, String key, Object value) {
-        if(value instanceof String)
-            target.put(key, (String) value);
-        else if(value instanceof Long)
-            target.put(key, (Long) value);
-        else if(value instanceof Integer)
-            target.put(key, (Integer) value);
-        else if(value instanceof Double)
+    public static void putInto(ContentValues target, String key, Object value, boolean errorOnFail) {
+        if (value instanceof Boolean)
+            target.put(key, (Boolean) value);
+        else if (value instanceof Byte)
+            target.put(key, (Byte) value);
+        else if (value instanceof Double)
             target.put(key, (Double) value);
-        else
+        else if (value instanceof Float)
+            target.put(key, (Float) value);
+        else if (value instanceof Integer)
+            target.put(key, (Integer) value);
+        else if (value instanceof Long)
+            target.put(key, (Long) value);
+        else if (value instanceof Short)
+            target.put(key, (Short) value);
+        else if (value instanceof String)
+            target.put(key, (String) value);
+        else if (errorOnFail)
             throw new UnsupportedOperationException("Could not handle type " + //$NON-NLS-1$
                     value.getClass());
     }

--- a/astrid/plugin-src/com/todoroo/astrid/gtasks/GtasksMetadataService.java
+++ b/astrid/plugin-src/com/todoroo/astrid/gtasks/GtasksMetadataService.java
@@ -191,7 +191,6 @@ public final class GtasksMetadataService extends SyncMetadataService<GtasksTaskC
         final AtomicInteger indentToMatch = new AtomicInteger(gtasksMetadata.getValue(GtasksMetadata.INDENT).intValue());
         final AtomicLong parentToMatch = new AtomicLong(gtasksMetadata.getValue(GtasksMetadata.PARENT_TASK).longValue());
         final AtomicReference<String> sibling = new AtomicReference<String>();
-
         OrderedListIterator iterator = new OrderedListIterator() {
             @Override
             public void processTask(long taskId, Metadata metadata) {

--- a/astrid/plugin-src/com/todoroo/astrid/gtasks/GtasksTaskListUpdater.java
+++ b/astrid/plugin-src/com/todoroo/astrid/gtasks/GtasksTaskListUpdater.java
@@ -166,8 +166,8 @@ public class GtasksTaskListUpdater extends OrderedListUpdater<StoreObject> {
     }
 
     private void updateParentSiblingMapsFor(StoreObject list) {
-        final AtomicLong previousTask = new AtomicLong(-1L);
-        final AtomicInteger previousIndent = new AtomicInteger(-1);
+        final AtomicLong previousTask = new AtomicLong(Task.NO_ID);
+        final AtomicInteger previousIndent = new AtomicInteger(0);
 
         gtasksMetadataService.iterateThroughList(list, new OrderedListIterator() {
             @Override
@@ -178,10 +178,13 @@ public class GtasksTaskListUpdater extends OrderedListUpdater<StoreObject> {
                     long parent, sibling;
                     if(indent > previousIndent.get()) {
                         parent = previousTask.get();
-                        sibling = -1L;
+                        sibling = Task.NO_ID;
                     } else if(indent == previousIndent.get()) {
                         sibling = previousTask.get();
-                        parent = parents.get(sibling);
+                        if (parents.containsKey(sibling))
+                            parent = parents.get(sibling);
+                        else
+                            parent = Task.NO_ID;
                     } else {
                         // move up once for each indent
                         sibling = previousTask.get();
@@ -190,7 +193,7 @@ public class GtasksTaskListUpdater extends OrderedListUpdater<StoreObject> {
                         if(parents.containsKey(sibling))
                             parent = parents.get(sibling);
                         else
-                            parent = -1L;
+                            parent = Task.NO_ID;
                     }
                     parents.put(taskId, parent);
                     siblings.put(taskId, sibling);

--- a/astrid/plugin-src/com/todoroo/astrid/gtasks/sync/GtasksSyncV2Provider.java
+++ b/astrid/plugin-src/com/todoroo/astrid/gtasks/sync/GtasksSyncV2Provider.java
@@ -184,6 +184,7 @@ public class GtasksSyncV2Provider extends SyncV2Provider {
                 try {
                     String authToken = getValidatedAuthToken();
                     callback.incrementProgress(25);
+                    gtasksSyncService.waitUntilEmpty();
                     final GtasksInvoker service = new GtasksInvoker(authToken);
                     synchronizeListHelper(gtasksList, service, manual, null, callback);
                 } finally {

--- a/astrid/plugin-src/com/todoroo/astrid/subtasks/OrderedListUpdater.java
+++ b/astrid/plugin-src/com/todoroo/astrid/subtasks/OrderedListUpdater.java
@@ -82,9 +82,9 @@ abstract public class OrderedListUpdater<LIST> {
 
         beforeIndent(list);
 
-        final AtomicInteger targetTaskIndent = new AtomicInteger(-1);
+        final AtomicInteger targetTaskIndent = new AtomicInteger(0);
         final AtomicInteger previousIndent = new AtomicInteger(-1);
-        final AtomicLong previousTask = new AtomicLong(-1);
+        final AtomicLong previousTask = new AtomicLong(Task.NO_ID);
         final AtomicLong globalOrder = new AtomicLong(-1);
 
         iterateThroughList(filter, list, new OrderedListIterator() {
@@ -146,7 +146,7 @@ abstract public class OrderedListUpdater<LIST> {
     private long computeNewParent(Filter filter, LIST list, long targetTaskId, int targetParentIndent) {
         final AtomicInteger desiredParentIndent = new AtomicInteger(targetParentIndent);
         final AtomicLong targetTask = new AtomicLong(targetTaskId);
-        final AtomicLong lastPotentialParent = new AtomicLong(-1);
+        final AtomicLong lastPotentialParent = new AtomicLong(Task.NO_ID);
         final AtomicBoolean computedParent = new AtomicBoolean(false);
 
         iterateThroughList(filter, list, new OrderedListIterator() {
@@ -228,7 +228,7 @@ abstract public class OrderedListUpdater<LIST> {
     }
 
     protected void traverseTreeAndWriteValues(LIST list, Node node, AtomicLong order, int indent) {
-        if(node.taskId != -1) {
+        if(node.taskId != Task.NO_ID) {
             Metadata metadata = getTaskMetadata(list, node.taskId);
             if(metadata == null)
                 metadata = createEmptyMetadata(list, node.taskId);
@@ -262,7 +262,7 @@ abstract public class OrderedListUpdater<LIST> {
     }
 
     protected Node buildTreeModel(Filter filter, LIST list) {
-        final Node root = new Node(-1, null);
+        final Node root = new Node(Task.NO_ID, null);
         final AtomicInteger previoustIndent = new AtomicInteger(-1);
         final AtomicReference<Node> currentNode = new AtomicReference<Node>(root);
 
@@ -364,7 +364,7 @@ abstract public class OrderedListUpdater<LIST> {
                 System.err.format("id %d: order %d, indent:%d, parent:%d\n", taskId, //$NON-NLS-1$
                         metadata.getValue(orderProperty()),
                         metadata.getValue(indentProperty()),
-                        parentProperty() == null ? -1 : metadata.getValue(parentProperty()));
+                        parentProperty() == null ? Task.NO_ID : metadata.getValue(parentProperty()));
             }
         });
     }

--- a/astrid/src/com/todoroo/astrid/service/TaskService.java
+++ b/astrid/src/com/todoroo/astrid/service/TaskService.java
@@ -437,11 +437,11 @@ public class TaskService {
 
                 for (Property<?> property : Metadata.PROPERTIES)
                     if (property.name.equals(key)) {
-                        AndroidUtilities.putInto(forMetadata, key, value);
+                        AndroidUtilities.putInto(forMetadata, key, value, true);
                         continue outer;
                     }
 
-                AndroidUtilities.putInto(forTask, key, value);
+                AndroidUtilities.putInto(forTask, key, value, true);
             }
             task.mergeWith(forTask);
         }


### PR DESCRIPTION
Added some helper methods to AbstractModel that allow transitories to be preserved when they go through the api dao, which fixes some issues caused by gtasks suppress sync flag not working.

Also fixed some bugs related to order/indentation by using Task.NO_ID in the list processors instead of -1.
