### PR TITLE
Fixed zombie lists.

### DIFF
--- a/astrid/plugin-src/com/todoroo/astrid/actfm/TagSettingsActivity.java
+++ b/astrid/plugin-src/com/todoroo/astrid/actfm/TagSettingsActivity.java
@@ -524,6 +524,7 @@ public class TagSettingsActivity extends FragmentActivity {
 
     protected boolean deleteTag() {
         boolean result = tagService.deleteOrLeaveTag(this, tagData.getValue(TagData.NAME), TagService.SHOW_ACTIVE_TASKS);
+        setResult(Activity.RESULT_OK);
         finish();
         return result;
     }

--- a/astrid/plugin-src/com/todoroo/astrid/actfm/TagViewFragment.java
+++ b/astrid/plugin-src/com/todoroo/astrid/actfm/TagViewFragment.java
@@ -485,8 +485,19 @@ public class TagViewFragment extends TaskListFragment {
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (requestCode == REQUEST_CODE_SETTINGS && resultCode == Activity.RESULT_OK) {
             tagData = tagDataService.fetchById(tagData.getId(), TagData.PROPERTIES); // refetch
-            if (tagData == null) // This can happen if a tag has been deleted as part of a sync
+            if (tagData == null) {
+                // This can happen if a tag has been deleted as part of a sync
                 return;
+            } else if (tagData.isDeleted()) {
+                // tag was deleted locally in settings
+                // go back to active tasks
+                FilterListFragment fl = ((AstridActivity) getActivity()).getFilterListFragment();
+                if (fl != null) {
+                    fl.switchToActiveTasks();
+                    fl.clear(); // Should auto refresh
+                }
+                return;
+            }
             filter = TagFilterExposer.filterFromTagData(getActivity(), tagData);
             getActivity().getIntent().putExtra(TOKEN_FILTER, filter);
             extras.putParcelable(TOKEN_FILTER, filter);


### PR DESCRIPTION
After deleting a list from its settings, it will go back to Active Tasks.

I removed the TagDeletedReceiver as I saw no way to get it triggered and solved this with the activityresult-mechanism within TagViewFragment.onActivityResult.
